### PR TITLE
MFLT-10177 Return more fields correctly from the latest release

### DIFF
--- a/sdk/src/main/java/com/memfault/cloud/sdk/MemfaultOtaPackage.kt
+++ b/sdk/src/main/java/com/memfault/cloud/sdk/MemfaultOtaPackage.kt
@@ -9,5 +9,6 @@ data class MemfaultOtaPackage(
     val appVersion: String,
     val md5: String,
     val extraInfo: Map<String, String>,
+    val releaseExtraInfo: Map<String, String>,
     val isForced: Boolean?,
 )

--- a/sdk/src/main/java/com/memfault/cloud/sdk/MemfaultOtaPackage.kt
+++ b/sdk/src/main/java/com/memfault/cloud/sdk/MemfaultOtaPackage.kt
@@ -2,6 +2,9 @@ package com.memfault.cloud.sdk
 
 /**
  * An OTA package, returned by Memfault's server for a specific [MemfaultDeviceInfo].
+ *
+ * @param size the size of the artifact at the [location]
+ * @param isDelta whether this package corresponds to a Delta or a Full Release.
  */
 data class MemfaultOtaPackage(
     val location: String,
@@ -11,4 +14,6 @@ data class MemfaultOtaPackage(
     val extraInfo: Map<String, String>,
     val releaseExtraInfo: Map<String, String>,
     val isForced: Boolean?,
+    val size: Long,
+    val isDelta: Boolean? = null,
 )

--- a/sdk/src/main/java/com/memfault/cloud/sdk/internal/GetLatestReleaseTask.kt
+++ b/sdk/src/main/java/com/memfault/cloud/sdk/internal/GetLatestReleaseTask.kt
@@ -39,7 +39,7 @@ class GetLatestReleaseTask internal constructor(
                 throw JSONException("Empty response body")
             }
             val jsonObject = JSONObject(body)
-            val otaPackage = jsonToOtaPackage(jsonObject)
+            val otaPackage = responseToOtaPackage(jsonObject)
             Runnable { callback.onUpdateAvailable(otaPackage) }
         } catch (e: JSONException) {
             Logger.e("Failed to parse JSON response", e)
@@ -62,21 +62,23 @@ class GetLatestReleaseTask internal constructor(
         private const val EXTRA_INFO = "extra_info"
         private const val IS_FORCED = "is_forced"
 
-        internal fun jsonToOtaPackage(jsonObject: JSONObject): MemfaultOtaPackage {
-            val artifactsObject = jsonObject.getJSONArray(ARTIFACTS).getJSONObject(0)
+        internal fun responseToOtaPackage(responseJson: JSONObject): MemfaultOtaPackage {
+            val artifactsObject = responseJson.getJSONArray(ARTIFACTS).getJSONObject(0)
             val url = artifactsObject.getString(URL)
-            val releaseNotes = jsonObject.getString(RELEASE_NOTES)
-            val appVersion = jsonObject.getString(APP_VERSION)
-            val isForced = jsonObject.getBooleanOrNull(IS_FORCED)
+            val releaseNotes = responseJson.getString(RELEASE_NOTES)
+            val appVersion = responseJson.getString(APP_VERSION)
+            val isForced = responseJson.getBooleanOrNull(IS_FORCED)
             val md5 = artifactsObject.getString(MD5)
-            val extraInfo = extraInfoToMap(artifactsObject)
+            val artifactsExtraInfo = extraInfoToMap(artifactsObject)
+            val releaseExtraInfo = extraInfoToMap(responseJson)
 
             return MemfaultOtaPackage(
                 location = url,
                 releaseNotes = releaseNotes,
                 appVersion = appVersion,
                 md5 = md5,
-                extraInfo = extraInfo,
+                extraInfo = artifactsExtraInfo,
+                releaseExtraInfo = releaseExtraInfo,
                 isForced = isForced,
             )
         }


### PR DESCRIPTION
3 changes:

 1. We want to surface the extra_info from the Release, not the Artifact only.
 2. Pass the size of the artifact through to the consumer
 3. Pass whether the release is known to be a delta release or not